### PR TITLE
FETI-128 / Zip Github Action with non-root user

### DIFF
--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -107,10 +107,20 @@ runs:
         file: ${{ steps.mode.outputs.artifact_name }}
         token: ${{ inputs.github_token }}
 
+    # Copies the current action's repository to the specified location, 
+    # so other actions from the same repo may be called (see sync below)
+    # This allows us to use the same version of the action for both "deploy" (the current action) and sync
+    - name: Copy custom action repository
+      shell: bash
+      run: bash ${{ github.action_path }}/../scripts/copy_actions_repo.sh
+      env:
+        CUSTOM_ACTION_REPO_SUBDIRECTORY: ${{ github.action_path }}
+        DESTINATION_PATH: ${{ github.workspace }}/.github/actions
+
     - name: Unzip release
       # If "promote release" mode, decompress the release asset
       if: ${{ inputs.release != '' }}
-      uses: montudor/action-zip@v1
+      uses: ./.github/actions/ConfigureID/gh-actions/zip
       with:
         args: unzip -qq ${{ steps.mode.outputs.artifact_name }} -d ./tmp
 
@@ -138,16 +148,6 @@ runs:
             core.error(`Error while adding publish info to metadata.json: ${err}`)
             core.setFailed(`Action failed with error ${err}`)
           }
-
-    # Copies the current action's repository to the specified location, 
-    # so other actions from the same repo may be called (see sync below)
-    # This allows us to use the same version of the action for both "deploy" (the current action) and sync
-    - name: Copy custom action repository
-      shell: bash
-      run: bash ${{ github.action_path }}/../scripts/copy_actions_repo.sh
-      env:
-        CUSTOM_ACTION_REPO_SUBDIRECTORY: ${{ github.action_path }}
-        DESTINATION_PATH: ${{ github.workspace }}/.github/actions
 
     # Sync to Cloud Service
     - name: Sync to Cloud Service

--- a/promote/action.yml
+++ b/promote/action.yml
@@ -76,11 +76,6 @@ runs:
         file: ${{ inputs.release_filename }}
         token: ${{ inputs.github_token }}
 
-    - name: Unzip release
-      uses: montudor/action-zip@v1
-      with:
-        args: unzip -qq ${{ inputs.release_filename }} -d ./tmp
-
     # Copies the current action's repository to the specified location, 
     # so other actions from the same repo may be called (see sync below)
     # This allows us to use the same version of the action for both "deploy" (the current action) and sync
@@ -90,6 +85,11 @@ runs:
       env:
         CUSTOM_ACTION_REPO_SUBDIRECTORY: ${{ github.action_path }}
         DESTINATION_PATH: ${{ github.workspace }}/.github/actions
+
+    - name: Unzip release
+      uses: ./.github/actions/ConfigureID/gh-actions/zip
+      with:
+        args: unzip -qq ${{ inputs.release_filename }} -d ./tmp
 
     # Sync to Cloud Service
     - name: Sync to Cloud Service

--- a/zip/Dockerfile
+++ b/zip/Dockerfile
@@ -4,5 +4,6 @@ RUN apk add zip
 
 # Create and assign runner user
 RUN addgroup --system --gid 127 docker
-RUN useradd --system -u 1001 -g 127 -ms /bin/bash runner
+RUN adduser --disabled-password --system --uid 1001 --ingroup "docker" --no-create-home --shell /bin/bash runner
+# RUN useradd --system -u 1001 -g 127 -ms /bin/bash runner
 USER runner

--- a/zip/Dockerfile
+++ b/zip/Dockerfile
@@ -2,8 +2,7 @@ FROM alpine:latest
 
 RUN apk add zip
 
-# Create and assign runner user
+# Create and assign runner user instead of root
 RUN addgroup --system --gid 127 docker
 RUN adduser --disabled-password --system --uid 1001 --ingroup "docker" --no-create-home --shell /bin/bash runner
-# RUN useradd --system -u 1001 -g 127 -ms /bin/bash runner
 USER runner

--- a/zip/Dockerfile
+++ b/zip/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:latest
+
+RUN apk add zip
+
+# Create and assign runner user
+RUN addgroup --system --gid 127 docker
+RUN useradd --system -u 1001 -g 127 -ms /bin/bash runner
+USER runner

--- a/zip/action.yml
+++ b/zip/action.yml
@@ -1,0 +1,9 @@
+name: "zip"
+description: "This GitHub action exposes the zip command for use in building/archiving"
+runs:
+  using: "docker"
+  image: "Dockerfile"
+inputs:
+  args:
+    description: "CMD to run"
+    required: false

--- a/zip/action.yml
+++ b/zip/action.yml
@@ -1,5 +1,5 @@
 name: "zip"
-description: "This GitHub action exposes the zip command for use in building/archiving"
+description: "Action that exposes the zip command for use in building/archiving. Same as montudor/action-zip but using non-root user"
 runs:
   using: "docker"
   image: "Dockerfile"


### PR DESCRIPTION
Fixes: FETI-128

Adds a local zip action based on [`montudor/action-zip`](https://github.com/montudor/action-zip) but using the same non-root user as the rest of the workflow.

This allows later actions to read/write/execute the extracted files