### PR TITLE
chore: unify zip - use the runner zip/unzip, drop Docker zip actions

### DIFF
--- a/attach-release-artifact/action.yml
+++ b/attach-release-artifact/action.yml
@@ -41,11 +41,8 @@ runs:
         echo "Artifact files count: $FILE_COUNT"
         echo "file_count=$FILE_COUNT" >> "$GITHUB_OUTPUT"
 
-    - name: Install zip
-      if: steps.count_files.outputs.file_count != '1'
-      uses: montudor/action-zip@v1
-
     - name: Compress files
+      # zip is preinstalled on the GitHub-hosted Ubuntu runners
       shell: bash
       if: steps.count_files.outputs.file_count != '1'
       run: zip -qq -r ../${{ inputs.filename }}.zip .

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -119,10 +119,10 @@ runs:
 
     - name: Unzip release
       # If "promote release" mode, decompress the release asset
+      # unzip is preinstalled on the GitHub-hosted Ubuntu runners
       if: ${{ inputs.release != '' }}
-      uses: ./.github/actions/ConfigureID/gh-actions/zip
-      with:
-        args: unzip -qq ${{ steps.mode.outputs.artifact_name }} -d ./tmp
+      shell: bash
+      run: unzip -qq ${{ steps.mode.outputs.artifact_name }} -d ./tmp
 
     # Loads metadata.json and adds the current CI run information a "publish info"
     - name: Add publish info to project metadata JSON

--- a/promote/action.yml
+++ b/promote/action.yml
@@ -87,9 +87,9 @@ runs:
         DESTINATION_PATH: ${{ github.workspace }}/.github/actions
 
     - name: Unzip release
-      uses: ./.github/actions/ConfigureID/gh-actions/zip
-      with:
-        args: unzip -qq ${{ inputs.release_filename }} -d ./tmp
+      # unzip is preinstalled on the GitHub-hosted Ubuntu runners
+      shell: bash
+      run: unzip -qq ${{ inputs.release_filename }} -d ./tmp
 
     # Sync to Cloud Service
     - name: Sync to Cloud Service

--- a/release/action.yml
+++ b/release/action.yml
@@ -37,10 +37,8 @@ runs:
         name: ${{ inputs.artifact_name }}
         path: ./tmp
 
-    - name: Install zip
-      uses: montudor/action-zip@v1
-
     - name: Compress files
+      # zip is preinstalled on the GitHub-hosted Ubuntu runners
       shell: bash
       run: zip -qq -r ../${{ inputs.release_filename }}.zip .
       working-directory: ./tmp

--- a/zip/Dockerfile
+++ b/zip/Dockerfile
@@ -1,8 +1,0 @@
-FROM alpine:3.24
-
-RUN apk add --no-cache zip
-
-# Create and assign runner user instead of root
-RUN addgroup --system --gid 127 docker
-RUN adduser --disabled-password --system --uid 1001 --ingroup "docker" --no-create-home --shell /bin/bash runner
-USER runner

--- a/zip/action.yml
+++ b/zip/action.yml
@@ -1,9 +1,0 @@
-name: "zip"
-description: "Action that exposes the zip command for use in building/archiving. Same as montudor/action-zip but using non-root user"
-runs:
-  using: "docker"
-  image: "Dockerfile"
-inputs:
-  args:
-    description: "CMD to run"
-    required: false


### PR DESCRIPTION
Removes the two zip Docker actions in favor of the `zip` / `unzip` already preinstalled on the GitHub-hosted Ubuntu runners.

## Why
The Ubuntu runners ship `zip` and `unzip` out of the box — both are listed under *Installed apt packages* in the [runner-images](https://github.com/actions/runner-images) manifests (ubuntu-24.04 = `ubuntu-latest`, and ubuntu-22.04). No Docker zip action is needed.

## Changes

### `release`, `attach-release-artifact` — remove `montudor/action-zip`
Used as a bare *"Install zip"* step (the pattern from montudor's own README). But a Docker container action runs in an isolated, ephemeral container and cannot install a binary onto the host runner, so that step never made `zip` available to the following `shell: bash` step — the actual compression already relied on the runner's `zip`. It was a no-op on Ubuntu runners; removed.

### `deploy`, `promote` — replace the local `zip` action with a host `unzip` step
These invoked the local `zip` Docker action with `args: unzip -qq … -d ./tmp`. Per the [GitHub docs](https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions), `with: args:` only reaches the container command when the action maps `runs.args: [ ${{ inputs.args }} ]` — which neither the local `zip` action nor `montudor/action-zip` do. So `args` was exposed only as the `INPUT_ARGS` env var and the container ran Alpine's default CMD (a no-op). The unzip most likely never ran inside the action; replacing it with a plain `unzip` step on the runner is both a simplification and a fix.

### Delete `zip/`
No longer referenced by any action.

## Verification
- No remaining references to `montudor` or `gh-actions/zip`
- All modified `action.yml` files YAML-validated
- **Not** verified on a live runner: GitHub Actions can't be executed locally here and the Docker daemon was unavailable to reproduce the `args` behaviour. The `runs.args` conclusion comes from the official docs + the `hello-world-docker-action` example; the runner `zip`/`unzip` availability is confirmed from the runner-images image manifests.

## Note
#46 is now merged. This PR touches `deploy` / `promote` too, but only the unzip step (#46 changed the download / deployment steps and left the unzip step untouched), so it merges cleanly against the updated `main`.
